### PR TITLE
[Version] Bump to latest Chrome version with COOP/COEP support

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -2,7 +2,7 @@
 
 We implement the threshold group testing based reduction in JS and Wasm for efficiently finding eviction sets of minimal size. For more details check our paper.
 
-Originally ested on _Chrome 74.0.3729.75 with V8 7.4_ with `--allow-natives-syntax` flags, but should also work on more recent versions of Chrome. Natives syntax is only required for validating of resulting JS offsets.
+Originally tested on _Chrome 74.0.3729.75 with V8 7.4_ with `--allow-natives-syntax` flags, but should also work on more recent versions of Chrome. Natives syntax is only required for validating of resulting JS offsets.
 
 Check my slides for more details about the Wasm implementation: https://vwzq.net/slides/2019-rootedcon_extended.pdf
 
@@ -29,7 +29,7 @@ $ python3 server.py
 $ ./run.sh
 ```
 
-You might need to modify `run.sh` with the right path to chrome.
+You might need to modify `run.sh` with the right path to chrome. Also make sure to visit `http://localhost:8000` and **not** `http://0.0.0.0:8000`, as cross-origin isolation is only enabled on `localhost` or when using HTTPS.
 
 ## Run
 

--- a/browser/README.md
+++ b/browser/README.md
@@ -2,7 +2,7 @@
 
 We implement the threshold group testing based reduction in JS and Wasm for efficiently finding eviction sets of minimal size. For more details check our paper.
 
-Tested on _Version 90.0.4430.93 (Official Build) (64-bit)_ with `--allow-natives-syntax` flags. Natives syntax is only required for validating of resulting JS offsets.
+Originally ested on _Chrome 74.0.3729.75 with V8 7.4_ with `--allow-natives-syntax` flags, but should also work on more recent versions of Chrome. Natives syntax is only required for validating of resulting JS offsets.
 
 Check my slides for more details about the Wasm implementation: https://vwzq.net/slides/2019-rootedcon_extended.pdf
 

--- a/browser/README.md
+++ b/browser/README.md
@@ -2,7 +2,7 @@
 
 We implement the threshold group testing based reduction in JS and Wasm for efficiently finding eviction sets of minimal size. For more details check our paper.
 
-Tested on *Chrome 74.0.3729.75 with V8 7.4* with `--allow-natives-syntax --experimental-wasm-bigint` flags. Natives syntax is only required for validating of resulting JS offsets. Wasm BigInt should be supported will be default soon.
+Tested on _Version 90.0.4430.93 (Official Build) (64-bit)_ with `--allow-natives-syntax` flags. Natives syntax is only required for validating of resulting JS offsets.
 
 Check my slides for more details about the Wasm implementation: https://vwzq.net/slides/2019-rootedcon_extended.pdf
 
@@ -25,7 +25,7 @@ $ clang virt_to_phys.c -o virt_to_phys
 Launch web server in current directory:
 
 ```
-$ python3 -m http.server --bind localhost
+$ python3 server.py
 $ ./run.sh
 ```
 

--- a/browser/run.sh
+++ b/browser/run.sh
@@ -1,3 +1,3 @@
 #!/bin/env /bin/bash
 
-google-chrome-beta --user-data-dir=/tmp/tmp.u9lo18kaTh --js-flags='--allow-natives-syntax --experimental-wasm-bigint' http://localhost:8000/ | ./verify_addr.sh
+google-chrome --user-data-dir=/tmp/tmp.u9lo18kaTh --js-flags='--allow-natives-syntax' http://localhost:8000/ | ./verify_addr.sh

--- a/browser/server.py
+++ b/browser/server.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+from http.server import HTTPServer, SimpleHTTPRequestHandler, test
+import sys
+
+class COOPCOEPRequestHandler (SimpleHTTPRequestHandler):
+    def end_headers (self):
+        self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+        SimpleHTTPRequestHandler.end_headers(self)
+
+if __name__ == '__main__':
+    test(COOPCOEPRequestHandler, HTTPServer, port=int(sys.argv[1]) if len(sys.argv) > 1 else 8000)

--- a/browser/verify_addr.sh
+++ b/browser/verify_addr.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 
 # Run:
-# $ google-chrome-beta --user-data-dir=/tmp/tmp.u9lo18kaTh --js-flags='--allow-natives-syntax --experimental-wasm-bigint' http://localhost:8000/ | ./verify_addr.sh
+# $ google-chrome --user-data-dir=/tmp/tmp.u9lo18kaTh --js-flags='--allow-natives-syntax' http://localhost:8000/ | ./verify_addr.sh
 #
 # Dependencies:
 # --allow-natives-stynax only used to verify offsets via command line
-# --experimental-wasm-bigint will be soon by default
 # pmap used to find offset of shared buffer (128*1024 KB)
 # gcc virt_to_phys.c -o virt_to_phys (used to translate virtual to physical, get slice and index set)
 
@@ -21,7 +20,7 @@ while true; do
 
 	# find right pid checking large allocated buffer
 	base=""
-	pids=$(ps aux | grep 'chrome-beta/chrome --type=renderer' | awk '{print $2}')
+	pids=$(ps aux | grep 'chrome/chrome --type=renderer' | awk '{print $2}')
 	for p in $pids; do
 		bases=$(pmap $p | grep '131072K' | awk '{print $1}')
 		if [ ! -z "$bases" ]; then
@@ -50,10 +49,10 @@ while true; do
 		if [[ $line =~ "Creating conflict set..." ]]; then
 			conflict=1
 		elif [[ $line =~ "Victim addr:" ]]; then
-			vic="$(echo $line | cut -d: -f 3 | cut -d\> -f 1)"
+			vic="$(echo $line | cut -d: -f 3 | cut -d\> -f 1 | cut -d\" -f 1)"
 			vic="$(printf '%x ' $(($base+$vic)))"
 		elif [[ $line =~ "Eviction set:" ]]; then
-			addresses="$(echo $line | cut -d: -f 3 | cut -d\> -f 1 | tr ',' ' ')"
+			addresses="$(echo $line | cut -d: -f 3 | cut -d\> -f 1 | cut -d\" -f 1 | tr ',' ' ')"
 			vaddrs=$(for o in $addresses; do printf '%x ' $(($base+$o)); done)
 			echo "Physical addresses:"
 			# needs sudo to work


### PR DESCRIPTION
Thanks for the nice repository!

I tried using the JS/WASM implementation with a more recent version of Chrome (_Version 90.0.4430.93 (Official Build) (64-bit)_) and created this PR for others that might want to test it on recent and coming versions.

**Changes:**
There was a syntax error in the `verify_addr.sh` script due to an additional `"`. Maybe the output changed with releases? Please correct me, if the error was on my side, but it also occured to me with the latest beta version of Chrome.
```
./verify_addr.sh: line 53: 0x000028d6ca230000+ 8128": syntax error: invalid arithmetic operator (error token is """)
./verify_addr.sh: line 56: 0x000028d6ca230000+101932992": syntax error: invalid arithmetic operator (error token is """)
```
Additionally, the `--experimental-wasm-bigint` flag is not longer needed, as the feature should now be enabled by default.
As cross-origin isolation will become mandatory soon in Chrome and already is mandatory in Firefox (more information [here](https://web.dev/coop-coep/)), I extended the simple Python HTTP server to also send along the necessary headers for testing purposes.

Hope this is useful to somebody!
Kind regards